### PR TITLE
Fix for error when adding a cut outside a nonlinear expression domain in ECP

### DIFF
--- a/pyomo/contrib/mindtpy/algorithm_base_class.py
+++ b/pyomo/contrib/mindtpy/algorithm_base_class.py
@@ -1857,6 +1857,27 @@ class _MindtPyAlgorithm(object):
 
     # The following functions deal with handling the solution we get from the above MIP solver function
 
+    def handle_nonlinear_var_values(self, main_mip, config):
+        """This function updates values of variables occuring in non-linear expressions by
+        bringing them back into their domain.
+
+        Parameters
+        ----------
+        main_mip : Pyomo model
+            The MIP main problem.
+        config : ConfigBlock
+            The specific configurations for MindtPy.
+        """
+        for constr in main_mip.MindtPy_utils.nonlinear_constraint_list:
+            constr_vars = list(EXPR.identify_variables(constr.body))
+            for var in constr_vars:
+                if var.lower is not None and var.value is not None:
+                    if var.value < var.lower:
+                        var.value = var.lower
+                if var.upper is not None and var.value is not None:
+                    if var.value > var.upper:
+                        var.value = var.upper
+
     def handle_main_optimal(self, main_mip, config, update_bound=True):
         """This function copies the results from 'solve_main' to the working model and updates
         the upper/lower bound. This function is called after an optimal solution is found for

--- a/pyomo/contrib/mindtpy/extended_cutting_plane.py
+++ b/pyomo/contrib/mindtpy/extended_cutting_plane.py
@@ -59,6 +59,7 @@ class MindtPy_ECP_Solver(_MindtPyAlgorithm):
             main_mip, main_mip_results = self.solve_main(config)
             if main_mip_results is not None:
                 if not config.single_tree:
+                    self.handle_nonlinear_var_values(main_mip, config)
                     if main_mip_results.solver.termination_condition is tc.optimal:
                         self.handle_main_optimal(main_mip, config)
                     elif main_mip_results.solver.termination_condition is tc.infeasible:


### PR DESCRIPTION
## Summary/Motivation:

In ECP, a cut could be added outside a nonlinear expression domain (e.g., x^0.5 at x = 1E-12), which results in complex coefficients being passed to the MIP solver. This raises an error.

## Changes proposed in this PR:
- Check if variable is outside its bound and move it to the bound
